### PR TITLE
Fix crash for video.kino.pub/play/78664?season_index=1&index=1

### DIFF
--- a/src/resources/lib/modeling.py
+++ b/src/resources/lib/modeling.py
@@ -314,7 +314,7 @@ class PlayableItem(ItemEntity):
             iconImage=self.item.get("posters", {}).get("small", ""),
             thumbnailImage=self.item.get("posters", {}).get("small", ""),
             poster=self.item.get("posters", {}).get("big"),
-            subtitles=[subtitle["url"] for subtitle in self.video_data["subtitles"]],
+            subtitles=[subtitle.get("url") for subtitle in self.video_data["subtitles"]],
         )
 
 


### PR DESCRIPTION
```
2022-04-27 20:33:20.358 T:2954     INFO <general>: initializing python engine.
2022-04-27 20:33:22.533 T:2954    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'KeyError'>
                                                   Error Contents: 'url'
                                                   Traceback (most recent call last):
                                                     File "/home/pi/.kodi/addons/video.kino.pub/addon.py", line 6, in <module>
                                                       plugin.run()
                                                     File "/home/pi/.kodi/addons/video.kino.pub/resources/lib/plugin.py", line 81, in run
                                                       self.routing.dispatch(self.path)
                                                     File "/home/pi/.kodi/addons/video.kino.pub/resources/lib/routing.py", line 62, in dispatch
                                                       view_func(**kwargs)
                                                     File "/home/pi/.kodi/addons/video.kino.pub/resources/lib/main.py", line 283, in play
                                                       playable_li = plugin.items.get_playable(item, season_index=si, index=i).playable_list_item
                                                     File "/home/pi/.kodi/addons/video.kino.pub/resources/lib/modeling.py", line 417, in playable_list_item
                                                       li = super(SeasonEpisode, self).playable_list_item
                                                     File "/home/pi/.kodi/addons/video.kino.pub/resources/lib/modeling.py", line 317, in playable_list_item
                                                       subtitles=[subtitle["url"] for subtitle in self.video_data["subtitles"]],
                                                     File "/home/pi/.kodi/addons/video.kino.pub/resources/lib/modeling.py", line 317, in <listcomp>
                                                       subtitles=[subtitle["url"] for subtitle in self.video_data["subtitles"]],
                                                   KeyError: 'url'
                                                   -->End of Python script error report<--
                                                   
2022-04-27 20:33:22.616 T:2954     INFO <general>: Python interpreter stopped
2022-04-27 20:33:22.638 T:653     ERROR <general>: Playlist Player: skipping unplayable item: 0, path [plugin://video.kino.pub/play/78664?season_index=1&index=1]
```